### PR TITLE
PagerDuty API requires HTTPS.

### DIFF
--- a/lib/pd.js
+++ b/lib/pd.js
@@ -1,6 +1,6 @@
 // Copyright 2013 Will Loderhose
 
-var http = require('http');
+var https = require('https');
 var moment = require('moment');
 var subdomain, api_key, service_key, service_ID, schedule_ID, policy_ID;
 
@@ -80,7 +80,7 @@ function trigger(description, details, callback) {
 		} 
 	};
 
-	var req = http.request(options, function(res) {
+	var req = https.request(options, function(res) {
 		res.setEncoding('utf-8');
 		var data;
 		res.on('data', function (chunk) {
@@ -135,7 +135,7 @@ function list(status, callback) {
 		}
 	};
 
-	var req = http.request(options, function(res) {
+	var req = https.request(options, function(res) {
 		res.setEncoding('utf-8');
 		var jData = '';
 		res.on('data', function (chunk) {
@@ -170,7 +170,7 @@ function who(callback) {
 		}
 	};
 
-	var req = http.request(options, function(res) {
+	var req = https.request(options, function(res) {
 		var jData = '';
 		
 		res.on('data', function (chunk) {
@@ -217,7 +217,7 @@ function getIDs(service_ID, callback) {
 		}
 	};
 
-	var req = http.request(options, function(res) {
+	var req = https.request(options, function(res) {
 		res.setEncoding('utf-8');
 		var jData = '';
 		res.on('data', function (chunk) {
@@ -236,7 +236,7 @@ function getIDs(service_ID, callback) {
 					}
 				};
 
-				var req2 = http.request(options2, function(res2) {
+				var req2 = https.request(options2, function(res2) {
 					res2.setEncoding('utf-8');
 					var jData2 = '';
 					res2.on('data', function (chunk) {


### PR DESCRIPTION
Updated all PD API calls to use HTTPS to avoid redirect HTML from breaking JSON parsing:

$ node bot.js
undefined:1
<html><body>You are being <a href="https://acme.pagerduty.com/api/v1/servic
^
SyntaxError: Unexpected token <

Tested this fix as working.
